### PR TITLE
Alphabetically sort checkbox in layout properties

### DIFF
--- a/public/javascript/newt/app-utilities.js
+++ b/public/javascript/newt/app-utilities.js
@@ -703,6 +703,7 @@ appUtilities.defaultLayoutProperties = {
     gravityRange: 3.8,
     initialEnergyOnIncremental: 0.3,
     improveFlow: true,
+    tileSortAscending: true, // Modified by Kisan Thapa
     packComponents: true,
 };
 

--- a/public/javascript/newt/backbone-views.js
+++ b/public/javascript/newt/backbone-views.js
@@ -292,6 +292,13 @@ var LayoutPropertiesView = Backbone.View.extend({
         delete extendedOptions.incremental;
         return extendedOptions;
     },
+    sortRandomly: function (layoutOptions) {
+        let randomize = true;
+        let tilingCompareBy = function (nodeId1, nodeId2) {
+            return 0;
+        };
+        return _.extend({}, layoutOptions, {randomize, tilingCompareBy});
+    },
     // Edit End here
 
     applyLayout: function (preferences, notUndoable, _chiseInstance) {
@@ -300,7 +307,10 @@ var LayoutPropertiesView = Backbone.View.extend({
         var options = this.getLayoutOptions(preferences, _chiseInstance);
 
         // Edited By Kisan Thapa
-        options = this.sortTilesByName(options);
+        if (options.tileSortAscending)
+            options = this.sortTilesByName(options);
+        else
+            options = this.sortRandomly(options);
         // Edit End here
 
         chiseInstance.performLayout(options, notUndoable);
@@ -372,6 +382,8 @@ var LayoutPropertiesView = Backbone.View.extend({
                 );
                 currentLayoutProperties.improveFlow =
                     document.getElementById('improve-flow').checked;
+                currentLayoutProperties.tileSortAscending =
+                    document.getElementById('tile-sort-ascending').checked;
                 // reset currentLayoutProperties in scratch pad
                 appUtilities.setScratch(cy, currentLayoutProperties, 'currentLayoutProperties');
 

--- a/views/index.html
+++ b/views/index.html
@@ -1884,6 +1884,17 @@
                                             </td>
                                         </tr>
 
+                                        <tr>
+                                            <td>
+                                                <span class="add-on layout-text"
+                                                      title="Whether to sort tiles by their name"> Sort Tiles by Name </span>
+                                            </td>
+                                            <td>
+                                                <input id="tile-sort-ascending" type="checkbox" class="layout-text" <% if
+                                                (tileSortAscending){ %> checked<%}%>>
+                                            </td>
+                                        </tr>
+
                                         </tbody>
                                     </table>
                                 </div>


### PR DESCRIPTION
Alphabetically sort tiles checkbox added in Layout Properties. Users can now choose whether to sort tiles/nodes by alphabetically or not.